### PR TITLE
Add loong64 support

### DIFF
--- a/.github/workflows/naive-build.yml
+++ b/.github/workflows/naive-build.yml
@@ -18,11 +18,11 @@ concurrency:
 
 jobs:
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64, "386", arm]
+        arch: [amd64, arm64, "386", arm, loong64]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,6 +36,10 @@ jobs:
       - name: Get Chromium version
         id: chromium
         run: echo "version=$(cat naiveproxy/CHROMIUM_VERSION)" >> $GITHUB_OUTPUT
+      - name: Regenerate Debian keyring
+        run: |
+          rm -f ./naiveproxy/src/build/linux/sysroot_scripts/keyring.gpg
+          GPG_TTY=/dev/null ./naiveproxy/src/build/linux/sysroot_scripts/generate_keyring.sh
       - name: Cache build artifacts
         id: build-cache
         uses: actions/cache@v4
@@ -94,12 +98,12 @@ jobs:
           fi
           ./cronet.test -test.v -test.run=TestEngineVersion
       - name: Build purego test binary
-        if: matrix.arch == 'amd64' || matrix.arch == 'arm64'
+        if: matrix.arch == 'amd64' || matrix.arch == 'arm64' || matrix.arch == 'loong64'
         run: |
           cp lib/linux_${{ matrix.arch }}/libcronet.so .
           CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.arch }} go test -tags with_purego -c -o cronet.purego.test .
       - name: Run purego test binary
-        if: matrix.arch == 'amd64' || matrix.arch == 'arm64'
+        if: matrix.arch == 'amd64' || matrix.arch == 'arm64' || matrix.arch == 'loong64'
         run: |
           if [ "${{ matrix.arch }}" != "amd64" ]; then
             eval $(go run ./cmd/build-naive --target=linux/${{ matrix.arch }} env --export)
@@ -363,11 +367,11 @@ jobs:
             include_cgo.go
 
   linux-musl:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64, "386", arm]
+        arch: [amd64, arm64, "386", arm, loong64]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -436,10 +440,11 @@ jobs:
         run: |
           # Static binary - can run directly with QEMU binfmt or explicit QEMU for cross-arch
           case "${{ matrix.arch }}" in
-            amd64) QEMU=qemu-x86_64 ;;
-            arm64) QEMU=qemu-aarch64 ;;
-            386)   QEMU=qemu-i386 ;;
-            arm)   QEMU=qemu-arm ;;
+            amd64)   QEMU=qemu-x86_64 ;;
+            arm64)   QEMU=qemu-aarch64 ;;
+            386)     QEMU=qemu-i386 ;;
+            arm)     QEMU=qemu-arm ;;
+            loong64) QEMU=qemu-loongarch64 ;;
           esac
           timeout 60 $QEMU ./cronet.test -test.v -test.run=TestEngineVersion -test.timeout=30s
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Go bindings for [naiveproxy](https://github.com/klzgrad/naiveproxy).
 | linux/386     | linux   | x86   |
 | linux/amd64   | linux   | x64   |
 | linux/arm     | linux   | arm   |
-| linux/arm64   | linux   | arm64 |
-| windows/amd64 | win     | x64   |
+| linux/arm64   | linux   | arm64   |
+| linux/loong64 | linux   | loong64 |
+| windows/amd64 | win     | x64     |
 | windows/arm64 | win     | arm64 |
 
 ## System Requirements
@@ -31,8 +32,8 @@ Go bindings for [naiveproxy](https://github.com/klzgrad/naiveproxy).
 | iOS/tvOS      | 15.0            |
 | Windows       | 10              |
 | Android       | 5.0 (API 21)    |
-| Linux (glibc) | glibc 2.31      |
-| Linux (musl)  | any             |
+| Linux (glibc)       | glibc 2.31 (loong64: 2.36) |
+| Linux (musl)        | any (loong64: 1.2.5)       |
 
 ## Downstream Build Requirements
 

--- a/cmd/build-naive/cmd.go
+++ b/cmd/build-naive/cmd.go
@@ -29,6 +29,7 @@ var allTargets = []Target{
 	{OS: "linux", CPU: "arm64", GOOS: "linux", ARCH: "arm64"},
 	{OS: "linux", CPU: "x86", GOOS: "linux", ARCH: "386"},
 	{OS: "linux", CPU: "arm", GOOS: "linux", ARCH: "arm"},
+	{OS: "linux", CPU: "loong64", GOOS: "linux", ARCH: "loong64"},
 	{OS: "mac", CPU: "x64", GOOS: "darwin", ARCH: "amd64"},
 	{OS: "mac", CPU: "arm64", GOOS: "darwin", ARCH: "arm64"},
 	{OS: "win", CPU: "x64", GOOS: "windows", ARCH: "amd64"},
@@ -206,6 +207,8 @@ func hostToCPU(goarch string) string {
 		return "x86"
 	case "arm":
 		return "arm"
+	case "loong64":
+		return "loong64"
 	default:
 		return goarch
 	}

--- a/internal/cronet/api_purego_float.go
+++ b/internal/cronet/api_purego_float.go
@@ -1,4 +1,4 @@
-//go:build with_purego && (amd64 || arm64)
+//go:build with_purego && (amd64 || arm64 || loong64)
 
 package cronet
 


### PR DESCRIPTION
`linux` and `linux-musl` jobs need to be upgraded from ubuntu-22.04 to ubuntu-24.04, as qemu-user-binfmt in Ubuntu 24.04 is required for loongarch64 emulation support.

Now loong64 supports cgo, purego, and musl builds, see: https://github.com/CAB233/cronet-go/actions/runs/22216775931

These are the integration tests I ran on the native loongarcg64.
[cgo-test.log](https://github.com/user-attachments/files/25437649/cgo-test.log)
[purego-test.log](https://github.com/user-attachments/files/25437650/purego-test.log)

