### PR TITLE
fix: copy DNS response before mutation to prevent cache corruption

### DIFF
--- a/naive_dns.go
+++ b/naive_dns.go
@@ -207,11 +207,15 @@ func wrapDNSResolverWithECH(
 					redirectedRequest.Question[0].Name = rewriteHTTPSQueryName(question.Name, serverName, echQueryServerName)
 					response = resolver(ctx, redirectedRequest)
 					if response != nil {
+						response = response.Copy()
 						response.Question = request.Question
 						rewriteHTTPSAnswerNames(response, echQueryServerName, serverName)
 					}
 				} else {
 					response = resolver(ctx, request)
+					if response != nil {
+						response = response.Copy()
+					}
 				}
 
 				filterIPHintsFromHTTPS(response)
@@ -426,6 +430,7 @@ func wrapDNSResolverForServerRedirect(
 
 		response := resolver(ctx, redirectedRequest)
 		if response != nil {
+			response = response.Copy()
 			response.Question = request.Question
 			rewriteAddressAnswerNames(response, serverAddress.AddrString(), serverName)
 		}


### PR DESCRIPTION
wrapDNSResolverForServerRedirect and wrapDNSResolverWithECH modify the DNS response returned by the upstream resolver in-place. However, this response object is already stored in sing-box's DNS cache by pointer. Mutating it corrupts the cached entry, causing subsequent lookups for the original domain to return mismatched names, resulting in ERR_NAME_NOT_RESOLVED.

Fix: call response.Copy() before any mutation.

Fixes SagerNet/sing-box#3810